### PR TITLE
Two fixes

### DIFF
--- a/guardianapi.py
+++ b/guardianapi.py
@@ -41,8 +41,14 @@ class ArticleFetcher():
         """Retrieves the total number of pages for the current operation"""
         r = requests.get(self.url % 1)
         resp = (json.loads(r.text))['response']
-        return min(self.max_pages, resp['pages'])
-        
+        if resp['status'] == 'error':
+            print("Error: " + resp['message'])
+        if self.max_pages == 0:
+            return resp['pages']
+        else:
+            return min(self.max_pages, resp['pages'])
+
+
     def get_data(self, page_number):
         """Fetches a page of articles from the API"""
         percent = 100.0 * page_number / self.total_pages


### PR DESCRIPTION
1. It seems the API requires an API key now. When I called it for the first time with defaults I got an error in the response saying a key was needed. So, if the response is an error, print out the message. It could raise some error too, but I let it just continue because at least it's printing something out.
2. There's a bug with `max_pages`. Documented as: "This the only paramenter that is not passed along to The Guardian API. If `max_pages` is left at 0, then it will retrieve as many pages as possible. Otherwise it will retrieve the minimum of the total number of pages avaible and `max_pages`." However, if it's left at it's default 0, the script returns the min of `max_pages` i.e. 0 and the number of pages returned by the API: so nothing is output. Instead, a special case is needed for when `max_pages` is 0.
